### PR TITLE
Prevent Autoloader from reading /autoload.php

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -66,7 +66,7 @@ class Autoloader
      */
     private static function getClassLoader() : ClassLoader
     {
-        if (file_exists(getenv('COMPOSER_VENDOR_DIR') . '/autoload.php')) {
+        if (getenv('COMPOSER_VENDOR_DIR') !== false && file_exists(getenv('COMPOSER_VENDOR_DIR') . '/autoload.php')) {
             return include getenv('COMPOSER_VENDOR_DIR') . '/autoload.php';
         }
 


### PR DESCRIPTION
```
PHP Warning:  file_exists(): open_basedir restriction in effect. File(/autoload.php) is not within the allowed path(s)
```

@dragonmantank In production environments reading `/autoload.php` (filesystem root) is not allowed.
