### PR TITLE
Create .gitattributes to prevent export of files with Composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto
+
+/.github export-ignore
+/test export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+CODE_OF_CONDUCT.md export-ignore
+CHANGELOG.md export-ignore
+CONTRIBUTING.md export-ignore
+phpcs.xml export-ignore
+phpstan.neon export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
I'm especially sending this in to prevent exporting `test/classes.php` when installing the package with Composer. This is messing up type hinting in IDE's and editors when `vonage/client-core` is also installed. For example, methods on the `Client` class of Vonage client core aren't clickable and signatures aren't showing. By ignoring this test file with class duplicates we can prevent this.